### PR TITLE
Suggestions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/fiskil/link-sdk/actions/workflows/test.yml/badge.svg)](https://github.com/fiskil/link-sdk/actions/workflows/test.yml)
 [![npm version](https://img.shields.io/npm/v/@fiskil/link.svg)](https://www.npmjs.com/package/@fiskil/link)
 
-The Fiskil Link SDK (@fiskil/link) makes it easy to embed a [Fiskil Auth Session](https://docs.fiskil.com/auth-session) inside your web application. An *Auth Session* is how end-users connect their bank or financial institution to share Consumer Data Right (CDR) data through the Fiskil platform.
+The Fiskil Link SDK (`@fiskil/link`) makes it easy to embed a [Fiskil Auth Session](https://docs.fiskil.com/auth-session) inside your web application. An *Auth Session* is how end-users connect their bank or financial institution to share Consumer Data Right (CDR) data through the Fiskil platform.
 
 This SDK handles the complete consent process and returns the outcome of the data sharing process - and you only need to provide a Fiskil `auth_session_id` to initiate and handle the result in your app. Once the user approves CDR sharing, your backend can listen for [Fiskil webhooks](https://docs.fiskil.com/guide/core-concepts/webhooks) and then begin fetching CDR data through Fiskil’s [Banking](https://docs.fiskil.com/banking/introduction) or [Energy](https://docs.fiskil.com/energy/introduction) APIs.
 
@@ -52,7 +52,6 @@ Creates and mounts the consent UI element. Returns a **`LinkFlow`** object, whic
 
 | Option          | Type   | Description                                                                    |
 | --------------- | ------ | ------------------------------------------------------------------------------ |
-| `allowedOrigin` | string | Restrict postMessage origin (recommended in production).                       |
 | `timeoutMs`     | number | Rejects if no message received within this time. defaults to `600000` (10 min) |
 
 ### Result
@@ -66,7 +65,7 @@ type LinkResult = {
 };
 ```
 
-- Resolved result includes `redirectURL` (as configured) and a `consentID` which can be used to fetch user data from fiskil platform.
+- Resolved result includes `consentID` which can be used to fetch user data from fiskil platform.
 - On failure, the promise rejects with a `LinkError` (see Error Handling).
 
 ### Error Handling


### PR DESCRIPTION
* Converts (@fiskil/link) to code block
* Removes allowedOrigin parameter from documentation. This is set to the production value by default so consumers should ignore it. We should only need to use it for internal testing
* Removes `redirectUrl` from result documentation since it's not really needed by the developer. Should we get rid of it from the link SDK result since we're pushing users to stop using the redirect flow?