### PR TITLE
Removes references to `allowedOrigin` in README and adds docs to allowedOrigin in type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Creates and mounts the consent UI element. Returns a **`LinkFlow`** object, whic
 
 | Option          | Type   | Description  |
 | --------------- | ------ | --------------------------- |
-| `allowedOrigin` | string | Restrict postMessage origin (recommended in production). |
 | `timeoutMs`     | number | Rejects if no message received within this time. defaults to `600000` (10 min) |
 
 ### Result

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,9 +29,21 @@ export type LinkResult = {
   consentID?: string;
 };
 
+// Options for customising the link behaviour
 export type LinkOptions = {
+  /**
+  * Origin to allow for incoming iframe messages. Should not be changed unless
+  * you are modifying \@fiskil/link itself
+  */
   allowedOrigin?: string;
+  /**
+  * The Fiskil authorization server. Should not be changed unless you are
+  * modifying \@fiskil/link itself
+  */
   authServer?: string;
+  /**
+  * Maximum amount of time to allow for the end-user's authentication
+  */
   timeoutMs?: number;
 };
 


### PR DESCRIPTION
This should stop users from using allowedOrigin
incorrectly. allowedOrigin defines the origin that
incoming iframe messages are accepted from which
should be the Fiskil authorization API in all
cases unless you are a Fiskil developer
